### PR TITLE
Added Device ID for TP-LINK Archer T1U

### DIFF
--- a/common/rtusb_dev_id.c
+++ b/common/rtusb_dev_id.c
@@ -36,6 +36,7 @@
 /* module table */
 USB_DEVICE_ID rtusb_dev_id[] = {
 #ifdef MT76x0
+	{USB_DEVICE(0x2357,0X0105)}, /* TP-LINK Archer T1U */
 	{USB_DEVICE(0x148F,0x7610)}, /* MT7610U Ralink VID */
 	{USB_DEVICE(0x0E8D,0x7610)}, /* MT7610U MediaTek VID / Sabrent NTWLAC */
 	{USB_DEVICE(0x13B1,0x003E)}, /* Cisco Linksys AE6000 */


### PR DESCRIPTION
my TP-LINK Archer T1U works with Debian Jessie and Linux Kernel 4.6 (jessie-backports). 

Linux debian-as 4.6.0-0.bpo.1-amd64 #1 SMP Debian 4.6.1-1~bpo8+1 (2016-06-14) x86_64 GNU/Linux
