### PR TITLE
enable `set_wiphy_netns` cmd to support namespace and fix signal being reported incorrectly by `iw dev` command

### DIFF
--- a/os/linux/cfg80211.c
+++ b/os/linux/cfg80211.c
@@ -2051,6 +2051,9 @@ static struct wireless_dev *CFG80211_WdevAlloc(
 	pWdev->wiphy->n_cipher_suites = ARRAY_SIZE(CipherSuites);
 #endif /* LINUX_VERSION_CODE */
 
+	/* @WIPHY_FLAG_NETNS_OK: if not set, do not allow changing the netns of this wiphy at all */
+        pWdev->wiphy->flags |=WIPHY_FLAG_NETNS_OK;
+	
 	if (wiphy_register(pWdev->wiphy) < 0)
 	{
 		DBGPRINT(RT_DEBUG_ERROR, ("80211> Register wiphy device fail!\n"));

--- a/os/linux/cfg80211drv.c
+++ b/os/linux/cfg80211drv.c
@@ -1206,7 +1206,7 @@ VOID CFG80211_Scaning(
 						ChanId,
 						pFrame,
 						FrameLen,
-						RSSI,
+						RSSI*100,
 						FlgIsNMode,
 						BW);
 #endif /* CONFIG_STA_SUPPORT */


### PR DESCRIPTION
Set WIPHY_FLAG_NETNS_OK in struct wiphy->flags to enable `set_wiphy_netns` command to support network namespace